### PR TITLE
my_plugin.c path incorrect for arduino?

### DIFF
--- a/my_plugin/probe select/my_plugin.c
+++ b/my_plugin/probe select/my_plugin.c
@@ -16,8 +16,8 @@
 */
 
 #ifdef ARDUINO
-#include "../grbl/hal.h"
-#include "../grbl/protocol.h"
+#include "../src/grbl/hal.h"
+#include "../src/grbl/protocol.h"
 #else
 #include "grbl/hal.h"
 #include "grbl/protocol.h"


### PR DESCRIPTION
Arduino library path seems to need /src added to find hal.h and compile correctly, at least on my Windows 10 setup.